### PR TITLE
Update requirements-dev.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
-awscli==1.27.8
-botocore==1.29.8
+awscli>=1.27.8
+botocore>=1.29.8
 colorama==0.4.4
 docutils==0.16
 jmespath==1.0.1


### PR DESCRIPTION
Change hardcoded AWSCLI and botocore 
*Depends on:*
- Links to any pull requests linked to this

_Description of what this PR does. What have you added or changed, and why?_
Current requirements hardcodes awscli and botocore at old, outdated versions, preventing installation of eks-token on updated systems.  Changed the comparison operator for both to >= to allow installation with newer versions of both.

# Steps to test
1.  try to install eks-token via pip with current version will fail with newer versions of awscli and/or botocore installed.
2.
3.